### PR TITLE
Fix Istanbul spelling in greeting message

### DIFF
--- a/utils/personality.py
+++ b/utils/personality.py
@@ -11,7 +11,7 @@ HELLO_MESSAGES = [
     "Hello! Forza Milan",
     "I live! And I bleed Red and Black",
     "Hello my Rossonero brother, what's up?",
-    "After Instanbul, we had Athens",
+    "After Istanbul, we had Athens",
     "Forza lotta, vincerai! Non ti lasceremo mai!",
     "It is true that I follow all the matches, but in truth, I am a Milanista.",
     "Forza Milan, louder today than yesterday, and louder tomorrow than today",


### PR DESCRIPTION
## Summary
- correct 'Instanbul' to 'Istanbul' in bot greeting message

## Testing
- `python -m py_compile utils/personality.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428338df0c8330b8f3b016eaae509d